### PR TITLE
Publish npm package from packed tgz artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Pack package
         run: |
-          package_tgz=$(pnpm pack --json | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).filename")
+          package_tgz=$(pnpm pack --json | jq -r '.filename')
           echo "PACKAGE_TGZ=$package_tgz" >> "$GITHUB_ENV"
 
       - name: Verify build artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Build package
         run: pnpm run build
 
+      - name: Pack package
+        run: |
+          package_tgz=$(pnpm pack --json | node -pe "JSON.parse(fs.readFileSync(0, 'utf8')).filename")
+          echo "PACKAGE_TGZ=$package_tgz" >> "$GITHUB_ENV"
+
       - name: Verify build artifacts
         run: |
           echo "Verifying build artifacts..."
@@ -67,8 +72,13 @@ jobs:
         env:
           DRY_RUN: "${{ inputs.dry-run }}"
         run: |
+          if [ -z "$PACKAGE_TGZ" ] || [ ! -f "$PACKAGE_TGZ" ]; then
+            echo "Error: packed tgz file not found: $PACKAGE_TGZ"
+            exit 1
+          fi
+
           if [ "$DRY_RUN" = true ]; then
-            npm publish --dry-run
+            npm publish "$PACKAGE_TGZ" --dry-run
           else
-            npm publish
+            npm publish "$PACKAGE_TGZ"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Pack package
         run: |
-          package_tgz=$(pnpm pack --json | node -pe "JSON.parse(fs.readFileSync(0, 'utf8')).filename")
+          package_tgz=$(pnpm pack --json | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).filename")
           echo "PACKAGE_TGZ=$package_tgz" >> "$GITHUB_ENV"
 
       - name: Verify build artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Pack package
         run: |
-          package_tgz=$(pnpm pack --json | jq -r '.filename')
+          package_tgz=$(pnpm pack --json | jq -er '.filename')
           echo "PACKAGE_TGZ=$package_tgz" >> "$GITHUB_ENV"
 
       - name: Verify build artifacts


### PR DESCRIPTION
`pnpm pack + npm publish` (for true [Trusted Publishing](https://docs.npmjs.com/trusted-publishers))

- https://pnpm.io/cli/publish

```
Since v11, pnpm publish is implemented natively and no longer delegates to the npm CLI. If you rely on a feature that is now gone, please open an issue at [pnpm/pnpm](https://github.com/pnpm/pnpm/issues). As a workaround, you can still run pnpm pack && npm publish *.tgz.
```

See Also:
- https://github.com/pnpm/pnpm/issues/9812
- https://github.com/pnpm/pnpm/issues/6607