### PR TITLE
chore(deps): block chai major updates (keep v4)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,13 +54,5 @@
     "arrow-body-style": ["off"],
     "grouped-accessor-pairs": ["warn"],
     "no-promise-executor-return": ["warn"]
-  },
-  "overrides": [
-    {
-      "files": ["gruntfile.js"],
-      "rules": {
-        "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
-      }
-    }
-  ]
+  }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
       "matchPackageNames": ["path-to-regexp"],
       "matchUpdateTypes": ["minor", "major"],
       "enabled": false
+    },
+    {
+      "description": "chai v5+ is ESM-only and breaks the CommonJS Mocha test setup (spec/config/setup.js uses require). Stay on v4 until the test stack is migrated to ESM.",
+      "matchPackageNames": ["chai"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const {Transform} = require('stream');
+// eslint-disable-next-line import/no-extraneous-dependencies
 const babel = require('@babel/core');
 
 const pkg = require('./package.json');


### PR DESCRIPTION
## Summary

Renovate keeps proposing a major `chai` upgrade (`4.x` → `6.x`, see #99), but that update **cannot work with the current test setup** and fails every CI test job.

Since chai **v5**, the package is **ESM-only** — `require('chai')` is no longer supported. Our Mocha harness is CommonJS and loads chai via `require`:

```js
// spec/config/setup.js
const chai = require('chai');
chai.use(require('chai-xml'));
chai.use(require('chai-datetime'));
chai.use(require('dirty-chai'));
```

So with chai 6 the test bootstrap fails before a single test runs:

```
ERROR: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../spec/config/setup'
       imported from .../mocha/lib/nodejs/esm-utils.js
```

On top of that, the plugins would need work too (`dirty-chai` requires `^3` for chai 6; `chai-datetime` / `chai-xml` have no chai-5/6 releases), so moving to chai 6 is a dedicated ESM migration, not a dependency bump.

This PR disables **major** chai updates in Renovate (minor/patch within 4.x stay enabled), mirroring the existing `path-to-regexp` rule. Once merged, Renovate will stop re-opening the chai v6 PR, so **#99 can be closed**.


