### PR TITLE
chore(deps): block dirty-chai major updates (requires chai 6)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,8 +8,8 @@
       "enabled": false
     },
     {
-      "description": "chai v5+ is ESM-only and breaks the CommonJS Mocha test setup (spec/config/setup.js uses require). Stay on v4 until the test stack is migrated to ESM.",
-      "matchPackageNames": ["chai"],
+      "description": "chai v5+ is ESM-only and breaks the CommonJS Mocha test setup (spec/config/setup.js uses require). dirty-chai v3 in turn requires chai 6 (peer: '>=6.2.0 <7'), so it's pinned too. Stay on chai 4 / dirty-chai 2 until the test stack is migrated to ESM.",
+      "matchPackageNames": ["chai", "dirty-chai"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     }


### PR DESCRIPTION
## Summary

Renovate keeps proposing a major `dirty-chai` upgrade (`2.x` → `3.x`, see #105), but that update **cannot work with the current test setup** and fails every CI test job.

`dirty-chai` **v3** requires **chai 6** (peer dependency `chai: '>=6.2.0 <7'`), while this project is intentionally pinned to **chai v4** (see #103). chai v5+ is ESM-only, so `dirty-chai@3` is ESM-only too, and our CommonJS Mocha harness loads it via `require`:

```js
// spec/config/setup.js
chai.use(require('dirty-chai'));
```

With `dirty-chai@3` the test bootstrap fails before a single test runs (same failure mode as the blocked chai v6 bump):

```
ERROR [ERR_MODULE_NOT_FOUND]: Cannot find module '.../spec/config/setup'
       imported from .../mocha/lib/nodejs/esm-utils.js
```

This is exactly the situation #103 anticipated:

> the plugins would need work too (`dirty-chai` requires `^3` for chai 6 ...), so moving to chai 6 is a dedicated ESM migration, not a dependency bump.

This PR disables **major** `dirty-chai` updates in Renovate (minor/patch within 2.x stay enabled), mirroring the existing `chai` and `path-to-regexp` rules. Once merged, Renovate will stop re-opening the dirty-chai v3 PR, so **#105 can be closed**.

