### PR TITLE
Bump package version to 4.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devextreme-exceljs-fork",
-  "version": "4.4.11",
+  "version": "4.4.12",
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "description": "Fork of Excel Workbook Manager - Read and Write xlsx and csv Files.",
   "private": false,


### PR DESCRIPTION
## What changed
- archiver 7 → 8
- dist/es5 back to true ES5 (Babel 8 regression)
- Babel 8, Node engine >= 22.21.1